### PR TITLE
Support linting Python files

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ It's suitable for using as a Git pre-commit hook.
 - Clone this repository, and run `python3 setup.py install`.
 - Install Difflint as a pre-commit hook by adding a line saying
   `difflint` to `.git/hooks/pre-commit` in the project that you want to
-  lint. (Create the `.git/hooks/pre-commit` file if it doesn't exist.)
+  lint.
+  (Create the `.git/hooks/pre-commit` file if it doesn't exist.
+  For Windows add `#!/bin/sh` first.)
   _You can set this up automatically for new git clones by putting it in
   your [Git template](http://git-scm.com/docs/git-init)._
 - Install JSCS and JSHint with `npm install -g jscs` and `npm install -g jshint`.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ It's suitable for using as a Git pre-commit hook.
 
 - [JSCS](http://jscs.info) (JavaScript)
 - [JSHint](http://jshint.com/docs) (JavaScript)
+- [PEP8](https://pypi.python.org/pypi/pep8) (Python)
+- [PyFlakes](https://pypi.python.org/pypi/pyflakes) (Python)
 
 ## Requirements ##
 

--- a/difflint/lint_output.py
+++ b/difflint/lint_output.py
@@ -1,0 +1,29 @@
+# Copyright 2015 Endless Mobile, Inc.
+
+import subprocess
+
+
+class LintOutput(object):
+    """Encapsulate linter output from multiple linters."""
+
+    def __init__(self):
+        self.output = ''
+        self._warnings_present = False
+
+    def has_warnings(self):
+        """Return whether any linters indicated errors or warnings."""
+        return self._warnings_present
+
+    def get_split_output(self):
+        """Return the linter output as an array of strings."""
+        return self.output.splitlines(keepends=True)
+
+    def run_command(self, args):
+        """Run the given linter command and capture its output and exit
+        code."""
+        try:
+            output_bytes = subprocess.check_output(args)
+        except subprocess.CalledProcessError as e:
+            output_bytes = e.output
+            self._warnings_present = True
+        self.output += output_bytes.decode()

--- a/difflint/lint_python.py
+++ b/difflint/lint_python.py
@@ -1,0 +1,60 @@
+# Copyright 2015 Endless Mobile, Inc.
+
+import pep8
+import pyflakes.api
+
+from .lint_output import LintOutput
+
+
+# We could do this with pep8.StandardReport and its format parameter directly,
+# but it prints to stdout by default. We don't want that.
+class _PEP8TerseReporter(pep8.BaseReport):
+    """Prints the PEP8 linter results in the expected "terse" format."""
+
+    def __init__(self):
+        super(_PEP8TerseReporter, self).__init__(pep8.StyleGuide().options)
+        self.output = ''
+
+    def error(self, line_number, offset, text, check):
+        code = super(_PEP8TerseReporter, self).error(line_number, offset, text,
+                                                     check)
+        self.output += '{}|{}|{}\n'.format(self.filename, code, text)
+        return code
+
+
+class _PyFlakesTerseReporter:
+    """A very minimal reimplementation of PyFlakes' Reporter class, changed
+    to print messages in the expected "terse" format. See:
+    https://github.com/pyflakes/pyflakes/blob/master/pyflakes/reporter.py
+    """
+
+    def __init__(self):
+        super(_PyFlakesTerseReporter, self).__init__()
+        self.output = ''
+
+    def unexpectedError(self, filename, msg):
+        self.output += '{}|FATAL|{}'.format(filename, msg)
+
+    def syntaxError(self, filename, msg, lineno, offset, text):
+        self.output += '{}|SYNTAX|{}'.format(filename, msg)
+
+    def flake(self, message):
+        message_text = message.message % message.message_args
+        self.output += '{}|FLAKE|{}'.format(message.filename, message_text)
+
+
+class PythonLintOutput(LintOutput):
+    def lint_pep8(self, file_to_lint):
+        reporter = _PEP8TerseReporter()
+        checker = pep8.Checker(filename=file_to_lint, report=reporter)
+        num_problems = checker.check_all()
+        if num_problems > 0:
+            self._warnings_present = True
+        self.output += reporter.output
+
+    def lint_pyflakes(self, file_to_lint):
+        reporter = _PyFlakesTerseReporter()
+        num_problems = pyflakes.api.checkPath(file_to_lint, reporter=reporter)
+        if num_problems > 0:
+            self._warnings_present = True
+        self.output += reporter.output

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,8 @@ setup(name='difflint', version='0.0.0',
           ],
       },
 
+      install_requires=['pep8', 'pyflakes'],
+
       # Metadata
       author='Devin Ekins',
       author_email='devinj.ekins@gmail.com',


### PR DESCRIPTION
This adds linting for Python files with the PEP8 and PyFlakes packages.
Instead of launching subprocesses for them, it's convenient enough to
run them through their Python API, and this makes it extra easy to
generate output in the required format. (PyFlakes doesn't support custom
reporters from the command line, as far as I can tell.)

This requires splitting LintOutput out into its own file, because
otherwise it would be a circular dependency.