### PR TITLE
Fixed merge conflict mangling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It's suitable for using as a Git pre-commit hook.
 
 ## Requirements ##
 
-- Python 3.3 or later
+- Python 3.5 or later
 - JSCS
 - JSHint
 - NPM for installing JSCS and JSHint


### PR DESCRIPTION
Previously, if we were in the middle of a merge conflict
our 'git stash' calls would mangle the conflict state.
Now we explictly save the merge conflict state and restore
it when we determine we were in the middle of a merge
conflict.

#5 