### PR TITLE
Linters are optional now

### DIFF
--- a/difflint/data/.difflintrc
+++ b/difflint/data/.difflintrc
@@ -1,0 +1,10 @@
+{
+    "javascript": {
+        "extensions": ["js"],
+        "linters": ["jshint", "jscs"]
+    },
+    "python": {
+        "extensions": ["py", "pyw"],
+        "linters": ["pep8", "pyflakes"]
+    }
+}

--- a/difflint/lib.py
+++ b/difflint/lib.py
@@ -12,7 +12,6 @@ from .lint import get_missing_configuration_files, get_missing_linters, lint
 LOG_FILE = 'lintdiff.log'
 MISSING_FILE_EXIT_CODE = 72  # os.EX_OSFILE is not portable
 
-
 def lint_list(file_list):
     """Lint every file in the list with a linter appropriate to its extension.
 
@@ -23,7 +22,6 @@ def lint_list(file_list):
              object.
     """
     return {f: lint(f) for f in file_list}
-
 
 def build_rename_dict():
     """Build a dictonary of the new filenames of renamed files.
@@ -53,7 +51,6 @@ def build_rename_dict():
         new_to_old[line_as_list[2]] = line_as_list[1]
     return new_to_old
 
-
 def build_file_list(mode_string):
     """Build a list of staged files matching certain diff-filter statuses.
 
@@ -74,11 +71,9 @@ def build_file_list(mode_string):
                                     '--diff-filter=' + mode_string])
     return list(git_diff_output.decode().split())
 
-
 def get_log_header():
     """Get a human-readable string header for the log file."""
     return str(datetime.utcnow().isoformat(' ')) + '\n'
-
 
 def diff_lint_outputs(past_mapping, current_mapping, log_output,
                       rename_mapping={}):
@@ -111,7 +106,6 @@ def diff_lint_outputs(past_mapping, current_mapping, log_output,
         log_output.write('\n\n\n')
         log_output.writelines(delta_generator)
 
-
 def report_defects_in_new_files(added_mapping, log_output):
     """Check LintOutput objects for the presence of warnings.
 
@@ -138,7 +132,6 @@ def report_defects_in_new_files(added_mapping, log_output):
         log_output.write(lint_output.output)
     return any_errors_introduced
 
-
 def finalize_log_output(log_output, any_new_errors):
     """Write the log to disk and print a message if there was something in it.
 
@@ -164,7 +157,6 @@ def finalize_log_output(log_output, any_new_errors):
             f.write(get_log_header())
             f.write(log_output.getvalue())
     log_output.close()
-
 
 def detect_new_diff_lint_errors(log_output):
     """Determine whether a linting diff indicates new errors.
@@ -203,7 +195,6 @@ def detect_new_diff_lint_errors(log_output):
         if error_regex.match(output_line):
             return True
     return False
-
 
 def main():
     parser = argparse.ArgumentParser(description='Linter that will examine ' +

--- a/difflint/lint.py
+++ b/difflint/lint.py
@@ -37,7 +37,6 @@ def _read_enabled_linters_config():
     with open(_ENABLED_LINTERS_CONFIG, 'r') as config:
         return json.load(config)
 
-
 def get_missing_configuration_files():
     """Check that all mandatory configuration files for difflint are
     in their expected locations.
@@ -52,7 +51,6 @@ def get_missing_configuration_files():
     if not os.path.isfile(_ENABLED_LINTERS_CONFIG):
         missing_configuration_files.append(_ENABLED_LINTERS_CONFIG)
     return missing_configuration_files
-
 
 def get_missing_linters():
     """Check that all enabled linters' external executables (as defined in the 
@@ -75,7 +73,6 @@ def get_missing_linters():
                                         'linter': linter})
     return missing_linters
 
-
 def _lint_jscs(file_to_lint, lint_output):
     jscs = shutil.which('jscs')
     lint_output.run_command([jscs, file_to_lint, '--reporter',
@@ -83,14 +80,12 @@ def _lint_jscs(file_to_lint, lint_output):
                                                'data/jscs_terse_reporter.js')])
     return lint_output
 
-
 def _lint_jshint(file_to_lint, lint_output):
     jshint = shutil.which('jshint')
     lint_output.run_command([jshint, file_to_lint, '--reporter',
                              resource_filename(__name__,
                                                'data/jshint_terse_reporter.js')])
     return lint_output
-
 
 def _lint_pep8(file_to_lint, lint_output):
     reporter = PEP8TerseReporter()
@@ -101,7 +96,6 @@ def _lint_pep8(file_to_lint, lint_output):
     lint_output.output += reporter.output
     return lint_output
 
-
 def _lint_pyflakes(file_to_lint, lint_output):
     reporter = PyFlakesTerseReporter()
     num_problems = pyflakes.api.checkPath(file_to_lint, reporter=reporter)
@@ -109,7 +103,6 @@ def _lint_pyflakes(file_to_lint, lint_output):
         lint_output._warnings_present = True
     lint_output.output += reporter.output
     return lint_output
-
 
 def lint(file_to_lint):
     """Perform linting on a file according to its extension.

--- a/difflint/lint.py
+++ b/difflint/lint.py
@@ -1,56 +1,148 @@
 # Copyright 2015 Endless Mobile, Inc.
 
+import json
 import os.path
+import pep8
 from pkg_resources import resource_filename
+import pyflakes.api
 import shutil
 
 from .lint_output import LintOutput
-from .lint_python import PythonLintOutput
+from .python_reporters import PEP8TerseReporter, PyFlakesTerseReporter
+
+_ENABLED_LINTERS_CONFIG = resource_filename(__name__, 'data/.difflintrc')
+
+def _read_enabled_linters_config():
+    """Reads from the configuration file to determine which linters
+    should be used for which file extensions.
+
+    Inputs: None
+
+    Output: A dictionary of languages mapped to a dictionary of extensions 
+            and linters.
+
+    Example Output Format:
+
+    {
+        "javascript": {
+            "extensions": ["js"],
+            "linters": ["jscs", "jshint"]
+        },
+        "python": {
+            "extensions": ["py", "pyw"],
+            "linters": ["pep8", "pyflakes"]
+        }
+    }
+    """
+    with open(_ENABLED_LINTERS_CONFIG, 'r') as config:
+        return json.load(config)
+
+
+def get_missing_configuration_files():
+    """Check that all mandatory configuration files for difflint are
+    in their expected locations.
+
+    Inputs: None
+
+    Output: A list of filepaths, as strings, of missing non-optional
+            configuration files. Will return an empty list if all
+            configuration files were found.
+    """
+    missing_configuration_files = []
+    if not os.path.isfile(_ENABLED_LINTERS_CONFIG):
+        missing_configuration_files.append(_ENABLED_LINTERS_CONFIG)
+    return missing_configuration_files
 
 
 def get_missing_linters():
-    """Check that all required external executables are in the PATH.
+    """Check that all enabled linters' external executables (as defined in the 
+    configuration file) are in the PATH.
 
-    Output: a list of executables that are not found, or an empty list if
-    everything is OK.
+    Inputs: None
+
+    Output: A list containing dictionaries of the form:
+
+                {'language': language, 'linter': linter_executable}
+
+            if any linters are not found. Otherwise returns an empty list.
     """
-    REQUIRED = ('jscs', 'jshint')
-    return [cmd for cmd in REQUIRED if shutil.which(cmd) is None]
+    enabled_linters_dict = _read_enabled_linters_config()
+    missing_linters = []
+    for language, language_dict in enabled_linters_dict.items():
+        for linter in language_dict['linters']:
+            if shutil.which(linter) is None:
+                missing_linters.append({'language': language,
+                                        'linter': linter})
+    return missing_linters
 
 
-def _lint_javascript(file_to_lint):
-    output = LintOutput()
+def _lint_jscs(file_to_lint, lint_output):
     jscs = shutil.which('jscs')
-    output.run_command([jscs, file_to_lint, '--reporter',
-                        resource_filename(__name__,
-                                          'data/jscs_terse_reporter.js')])
+    lint_output.run_command([jscs, file_to_lint, '--reporter',
+                             resource_filename(__name__,
+                                               'data/jscs_terse_reporter.js')])
+    return lint_output
 
+
+def _lint_jshint(file_to_lint, lint_output):
     jshint = shutil.which('jshint')
-    output.run_command([jshint, file_to_lint, '--reporter',
-                        resource_filename(__name__,
-                                          'data/jshint_terse_reporter.js')])
-    return output
+    lint_output.run_command([jshint, file_to_lint, '--reporter',
+                             resource_filename(__name__,
+                                               'data/jshint_terse_reporter.js')])
+    return lint_output
 
 
-def _lint_python(file_to_lint):
-    output = PythonLintOutput()
-    output.lint_pep8(file_to_lint)
-    output.lint_pyflakes(file_to_lint)
-    return output
+def _lint_pep8(file_to_lint, lint_output):
+    reporter = PEP8TerseReporter()
+    checker = pep8.Checker(filename=file_to_lint, report=reporter)
+    num_problems = checker.check_all()
+    if num_problems > 0:
+        lint_output._warnings_present = True
+    lint_output.output += reporter.output
+    return lint_output
+
+
+def _lint_pyflakes(file_to_lint, lint_output):
+    reporter = PyFlakesTerseReporter()
+    num_problems = pyflakes.api.checkPath(file_to_lint, reporter=reporter)
+    if num_problems > 0:
+        lint_output._warnings_present = True
+    lint_output.output += reporter.output
+    return lint_output
 
 
 def lint(file_to_lint):
     """Perform linting on a file according to its extension.
 
-    Inputs:
-        file_to_lint: Path to a file to lint, as a string.
+    Inputs: Path to a file to lint, as a string.
+
     Output: A LintOutput object with linting results.
     """
     root, ext = os.path.splitext(file_to_lint)
 
-    if ext == '.js':
-        return _lint_javascript(file_to_lint)
-    if ext == '.py':
-        return _lint_python(file_to_lint)
+    # Strip the leading period to match the format in the configuration file.
+    ext = ext[1:]
 
-    # TODO: Other file extensions/linters will be added here.
+    config = _read_enabled_linters_config()
+
+    linters_to_run = []
+    for language, language_dict in config.items():
+        if ext in language_dict['extensions']:
+            linters_to_run.extend(language_dict['linters'])
+
+    output = LintOutput()
+
+    # Other file extensions/linters must be added here if they are to be used.
+    for linter in linters_to_run:
+        if linter == 'jshint':
+            output = _lint_jshint(file_to_lint, output)
+        elif linter == 'jscs':
+            output = _lint_jscs(file_to_lint, output)
+        elif linter == 'pep8':
+            output = _lint_pep8(file_to_lint, output)
+        elif linter == 'pyflakes':
+            output = _lint_pyflakes(file_to_lint, output)
+        else:
+            raise ValueError('Unknown linter found in configuration file: "' +
+                             linter + '"')
+    return output

--- a/difflint/python_reporters.py
+++ b/difflint/python_reporters.py
@@ -1,35 +1,32 @@
 # Copyright 2015 Endless Mobile, Inc.
 
 import pep8
-import pyflakes.api
-
-from .lint_output import LintOutput
 
 
 # We could do this with pep8.StandardReport and its format parameter directly,
 # but it prints to stdout by default. We don't want that.
-class _PEP8TerseReporter(pep8.BaseReport):
+class PEP8TerseReporter(pep8.BaseReport):
     """Prints the PEP8 linter results in the expected "terse" format."""
 
     def __init__(self):
-        super(_PEP8TerseReporter, self).__init__(pep8.StyleGuide().options)
+        super(PEP8TerseReporter, self).__init__(pep8.StyleGuide().options)
         self.output = ''
 
     def error(self, line_number, offset, text, check):
-        code = super(_PEP8TerseReporter, self).error(line_number, offset, text,
-                                                     check)
+        code = super(PEP8TerseReporter, self).error(line_number, offset, text,
+                                                    check)
         self.output += '{}|{}|{}\n'.format(self.filename, code, text)
         return code
 
 
-class _PyFlakesTerseReporter:
+class PyFlakesTerseReporter:
     """A very minimal reimplementation of PyFlakes' Reporter class, changed
     to print messages in the expected "terse" format. See:
     https://github.com/pyflakes/pyflakes/blob/master/pyflakes/reporter.py
     """
 
     def __init__(self):
-        super(_PyFlakesTerseReporter, self).__init__()
+        super(PyFlakesTerseReporter, self).__init__()
         self.output = ''
 
     def unexpectedError(self, filename, msg):
@@ -41,20 +38,3 @@ class _PyFlakesTerseReporter:
     def flake(self, message):
         message_text = message.message % message.message_args
         self.output += '{}|FLAKE|{}'.format(message.filename, message_text)
-
-
-class PythonLintOutput(LintOutput):
-    def lint_pep8(self, file_to_lint):
-        reporter = _PEP8TerseReporter()
-        checker = pep8.Checker(filename=file_to_lint, report=reporter)
-        num_problems = checker.check_all()
-        if num_problems > 0:
-            self._warnings_present = True
-        self.output += reporter.output
-
-    def lint_pyflakes(self, file_to_lint):
-        reporter = _PyFlakesTerseReporter()
-        num_problems = pyflakes.api.checkPath(file_to_lint, reporter=reporter)
-        if num_problems > 0:
-            self._warnings_present = True
-        self.output += reporter.output

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name='difflint', version='0.0.0',
       packages=find_packages(),
       package_data={
-          'difflint': ['data/*'],
+          'difflint': ['data/*', 'data/.difflintrc'],
       },
 
       entry_points={


### PR DESCRIPTION
Previously we required the Javascript linters jscs and
jshint and would abort the program if they were not found.
We also tightly coupled our hardcoded file extensions to
the linters we supported, limiting situations where someone
wanted to use a linter for a file extension we did not
anticipate.

The biggest victory, however, is our newfound ability to
enable or disable supported linters via the new
enabled_linters.json file. As of this commit, the file will
be installed in the data folder of difflint but in the future
we will want to support user-customizable overrides in their
repository root, following the same JSON format.

One casualty of decoupling the linters from file extensions
is that we are not able to easily support various LintOutput
classes. This forced me to move the logic for the python
linters to the lint.py file and rename the lint_python.py file
to reflect the fact that it only contains reporters now.

Another modification was to enhance the functionality of the
--check mode and the automatic checking for linters at runtime
in the normal execution mode. They now will both use the
configuration file to determine which linters are required.

#8 